### PR TITLE
CodeCard: fix leaking content after adding header

### DIFF
--- a/src/app/components/cards/code-card/code-card.component.scss
+++ b/src/app/components/cards/code-card/code-card.component.scss
@@ -4,6 +4,8 @@
 $code-line-border: 1px solid $color-white;
 
 :host {
+  display: flex;
+  flex-direction: column;
   padding: $card-padding;
 
   color: $color-white;


### PR DESCRIPTION
Content of code card started leaking outside container after adding header. This PR implements a fix for this bug.